### PR TITLE
Don't write warnings to reports and don't print report if written to file

### DIFF
--- a/PHP/CompatInfo/Report.php
+++ b/PHP/CompatInfo/Report.php
@@ -77,6 +77,15 @@ abstract class PHP_CompatInfo_Report
 
         $this->generate($report, $base, $options['verbose']);
 
+        if (isset($options['reportFile'])) {
+            $generatedReport = ob_get_clean();
+
+            file_put_contents(
+                $options['reportFile'], $generatedReport,
+                $options['reportFileFlags']
+            );
+        }
+
         if (count($allWarnings) > 0 && $options['verbose'] > 0) {
             echo 'Warning messages : (' . count($allWarnings) . ')' . PHP_EOL;
             echo PHP_EOL;
@@ -87,16 +96,6 @@ abstract class PHP_CompatInfo_Report
                 }
                 echo '  ' . $warn . PHP_EOL;
             }
-        }
-
-        if (isset($options['reportFile'])) {
-            $generatedReport = ob_get_contents();
-            ob_end_flush();
-
-            file_put_contents(
-                $options['reportFile'], $generatedReport,
-                $options['reportFileFlags']
-            );
         }
     }
 


### PR DESCRIPTION
Warnings were written to the report file which causes invalid XML. It can also mask them.

I've also disabled printing the report if it is written to file. It's painful with large reports.
