### PR TITLE
Avoid deadlock in object operator

### DIFF
--- a/PHP/CompatInfo/Token/ObjectOperator.php
+++ b/PHP/CompatInfo/Token/ObjectOperator.php
@@ -66,6 +66,9 @@ class PHP_CompatInfo_Token_OBJECT_OPERATOR extends PHP_Reflect_Token_OBJECT_OPER
             while ($this->_getContext($i) != 'T_OPEN_TAG'
                 && $this->_getContext($i) != 'T_SEMICOLON'
                 && $this->_getContext($i) != 'T_OBJECT_OPERATOR'
+                && $this->_getContext($i) != 'T_PAAMAYIM_NEKUDOTAYIM'
+                && $this->_getContext($i) != 'T_OPEN_CURLY'
+                && $this->_getContext($i) !== false
             ) {
                 if ($this->_getContext($i) == 'T_CLOSE_BRACKET') {
                     $bracket++;


### PR DESCRIPTION
It deadlocks on this code: `A::b()->c`.

Surprisingly `T_OPEN_TAG` is not reported on the beginning of the file.
