### PR TITLE
Prevent division by zero PHP warning from progressbar when nothing parsed

### DIFF
--- a/PHP/CompatInfo.php
+++ b/PHP/CompatInfo.php
@@ -458,6 +458,10 @@ class PHP_CompatInfo implements SplSubject, IteratorAggregate, Countable
         $files = self::getFilelist(
             $dataSource, $this->options['recursive'], $excludes
         );
+        $filesCount = count($files);
+        if ($filesCount < 1) {
+            return false;
+        }
 
         if (php_sapi_name() === 'cli'
             && isset($this->options['consoleProgress'])
@@ -469,19 +473,17 @@ class PHP_CompatInfo implements SplSubject, IteratorAggregate, Countable
         }
         if ($consoleProgress) {
             $out      = new ezcConsoleOutput();
-            $progress = new ezcConsoleProgressbar($out, count($files));
+            $progress = new ezcConsoleProgressbar($out, $filesCount);
         }
 
         $this->results = array();
         $i             = 0;
-        $indexes       = count($files);
-        $process       = ($indexes > 0);
 
         foreach ($files as $source) {
             $i++;
-            $this->startScanFile($source, $i, $indexes);
+            $this->startScanFile($source, $i, $filesCount);
             $this->scan($source);
-            $this->endScanFile($source, $i, $indexes);
+            $this->endScanFile($source, $i, $filesCount);
 
             if ($consoleProgress) {
                 $progress->advance();
@@ -493,7 +495,7 @@ class PHP_CompatInfo implements SplSubject, IteratorAggregate, Countable
 
         $this->endScanSource();
 
-        return $process;
+        return true;
     }
 
     /**


### PR DESCRIPTION
Example:

$ mkdir /tmp/newdir
$ phpci print /tmp/newdir/
PHP Warning:  Division by zero in /usr/share/pear/ezc/ConsoleTools/progressbar.php on line 367
PHP Stack trace:
PHP   1. {main}() /usr/bin/phpci:0
PHP   2. PHP_CompatInfo_CLI::main() /usr/bin/phpci:6
PHP   3. PHP_CompatInfo_CLI::factory() /usr/share/pear/Bartlett/PHP/CompatInfo/CLI.php:580
PHP   4. PHP_CompatInfo_Report->__construct() /usr/share/pear/Bartlett/PHP/CompatInfo/CLI.php:615
PHP   5. PHP_CompatInfo->parse() /usr/share/pear/Bartlett/PHP/CompatInfo/Report.php:59
PHP   6. ezcConsoleProgressbar->finish() /usr/share/pear/Bartlett/PHP/CompatInfo.php.orig:491
PHP   7. ezcConsoleProgressbar->output() /usr/share/pear/ezc/ConsoleTools/progressbar.php:356
PHP   8. ezcConsoleProgressbar->generateValues() /usr/share/pear/ezc/ConsoleTools/progressbar.php:323
PHP Warning:  Division by zero in /usr/share/pear/ezc/ConsoleTools/progressbar.php on line 386
PHP Stack trace:
PHP   1. {main}() /usr/bin/phpci:0
PHP   2. PHP_CompatInfo_CLI::main() /usr/bin/phpci:6
PHP   3. PHP_CompatInfo_CLI::factory() /usr/share/pear/Bartlett/PHP/CompatInfo/CLI.php:580
PHP   4. PHP_CompatInfo_Report->__construct() /usr/share/pear/Bartlett/PHP/CompatInfo/CLI.php:615
PHP   5. PHP_CompatInfo->parse() /usr/share/pear/Bartlett/PHP/CompatInfo/Report.php:59
PHP   6. ezcConsoleProgressbar->finish() /usr/share/pear/Bartlett/PHP/CompatInfo.php.orig:491
PHP   7. ezcConsoleProgressbar->output() /usr/share/pear/ezc/ConsoleTools/progressbar.php:356
PHP   8. ezcConsoleProgressbar->generateValues() /usr/share/pear/ezc/ConsoleTools/progressbar.php:323
0 / 0 [>-------------------------------------------------------------]   0.00%
## PHP COMPAT INFO REPORT SUMMARY
## FILES                         EXTENSIONS INTERFACES CLASSES FUNCTIONS CONSTANTS

---
## Time: 1 second, Memory: 8.50Mb
