### PR TITLE
Change in curl extension for PHP 5.4.7

### DIFF
--- a/PHP/CompatInfo/Reference/curl.php
+++ b/PHP/CompatInfo/Reference/curl.php
@@ -462,6 +462,10 @@ class PHP_CompatInfo_Reference_Curl implements PHP_CompatInfo_Reference
 
                 'CURLINFO_CERTINFO'              => array('5.3.2', ''),
                 'CURLINFO_HEADER_OUT'            => array('5.1.3', ''),
+                'CURLINFO_LOCAL_IP'              => array('5.4.7-dev', ''),
+                'CURLINFO_LOCAL_PORT'            => array('5.4.7-dev', ''),
+                'CURLINFO_PRIMARY_IP'            => array('5.4.7-dev', ''),
+                'CURLINFO_PRIMARY_PORT'          => array('5.4.7-dev', ''),
                 'CURLINFO_PRIVATE'               => array('5.2.4', ''),
                 'CURLINFO_REDIRECT_URL'          => array('5.3.7', ''),
 

--- a/tests/Reference/CurlTest.php
+++ b/tests/Reference/CurlTest.php
@@ -69,9 +69,10 @@ class PHP_CompatInfo_Reference_CurlTest
                     'CURLINFO_REDIRECT_URL'
                 );
             }
-            if ($ver<0x071300) {
+            if ($ver<0x071300) { // 7.19.0
                 array_push(
                     $this->optionnalconstants,
+                    'CURLINFO_PRIMARY_IP',
                     'CURLSSH_AUTH_NONE',
                     'CURLSSH_AUTH_PUBLICKEY',
                     'CURLSSH_AUTH_PASSWORD',
@@ -112,6 +113,14 @@ class PHP_CompatInfo_Reference_CurlTest
                     'CURLPROTO_FILE',
                     'CURLPROTO_TFTP',
                     'CURLPROTO_ALL'
+                );
+            }
+            if ($ver<0x071500) { // 7.21.0
+                array_push(
+                    $this->optionnalconstants,
+                    'CURLINFO_LOCAL_IP',
+                    'CURLINFO_LOCAL_PORT',
+                    'CURLINFO_PRIMARY_PORT'
                 );
             }
         }


### PR DESCRIPTION
```
PHP Version tested: 5.4.7RC1

PHPUnit 3.6.12 by Sebastian Bergmann.

...............................................................  63 / 637 (  9%)
............................................................... 126 / 637 ( 19%)
............................................................... 189 / 637 ( 29%)
............................................................... 252 / 637 ( 39%)
............................................................... 315 / 637 ( 49%)
............................................................... 378 / 637 ( 59%)
............................................................... 441 / 637 ( 69%)
............................................................... 504 / 637 ( 79%)
............................................................... 567 / 637 ( 89%)
............................................................... 630 / 637 ( 98%)
.......

Time: 20 seconds, Memory: 532.75Mb

OK (637 tests, 9549 assertions)
```
