### PR TITLE
fix XCache test

### DIFF
--- a/tests/Reference/XCacheTest.php
+++ b/tests/Reference/XCacheTest.php
@@ -41,6 +41,12 @@ class PHP_CompatInfo_Reference_XCacheTest
      */
     protected function setUp()
     {
+        $this->optionnalfunctions = array(
+            // Requires specific build optons
+            // so not available everywhere
+            'xcache_dasm_file',
+            'xcache_dasm_string',
+        );
         $this->obj = new PHP_CompatInfo_Reference_XCache();
         parent::setUp();
     }


### PR DESCRIPTION
This functions are not available as they requires --enable-xcache-disassembler, which is marked as "NOT for production server"
