### PR TITLE
ignore new features of JSONC alternative extension

### DIFF
--- a/tests/Reference/JsonTest.php
+++ b/tests/Reference/JsonTest.php
@@ -41,6 +41,13 @@ class PHP_CompatInfo_Reference_JsonTest
      */
     protected function setUp()
     {
+        // New features of JSONC alternative extension
+        $this->ignoredconstants = array(
+            'JSON_PARSER_NOTSTRICT',
+        );
+        $this->ignoredclasses = array(
+            'JsonIncrementalParser',
+        );
         $this->obj = new PHP_CompatInfo_Reference_Json();
         parent::setUp();
     }


### PR DESCRIPTION
The new JSONC alternative extension have replaced JSON standard non free extension in various Linux distro, with PHP 5.5
- Fedora 19
- Mageia (chauldron)
- Debian (unstable)
