### PR TITLE
fix Intl reference (libicu >= 49)

### DIFF
--- a/PHP/CompatInfo/Reference/intl.php
+++ b/PHP/CompatInfo/Reference/intl.php
@@ -342,6 +342,10 @@ class PHP_CompatInfo_Reference_Intl
                                                 => array('5.5.0', ''),
             'intlcal_get_minimum'               => array('5.5.0', ''),
             'intlcal_get_now'                   => array('5.5.0', ''),
+            'intlcal_get_repeated_wall_time_option'
+                                                => array('5.5.0', ''),
+            'intlcal_get_skipped_wall_time_option'
+                                                => array('5.5.0', ''),
             'intlcal_get_time'                  => array('5.5.0', ''),
             'intlcal_get_time_zone'             => array('5.5.0', ''),
             'intlcal_get_type'                  => array('5.5.0', ''),
@@ -355,6 +359,10 @@ class PHP_CompatInfo_Reference_Intl
             'intlcal_set'                       => array('5.5.0', ''),
             'intlcal_set_first_day_of_week'     => array('5.5.0', ''),
             'intlcal_set_lenient'               => array('5.5.0', ''),
+            'intlcal_set_repeated_wall_time_option'
+                                                => array('5.5.0', ''),
+            'intlcal_set_skipped_wall_time_option'
+                                                => array('5.5.0', ''),
             'intlcal_set_time'                  => array('5.5.0', ''),
             'intlcal_set_time_zone'             => array('5.5.0', ''),
             'intlcal_to_date_time'              => array('5.5.0', ''),
@@ -377,6 +385,7 @@ class PHP_CompatInfo_Reference_Intl
             'intltz_get_offset'                 => array('5.5.0', ''),
             'intltz_get_raw_offset'             => array('5.5.0', ''),
             'intltz_get_region'                 => array('5.5.0', ''),
+            'intltz_get_unknown'                => array('5.5.0', ''),
             'intltz_get_tz_data_version'        => array('5.5.0', ''),
             'intltz_has_same_rules'             => array('5.5.0', ''),
             'intltz_to_date_time_zone'          => array('5.5.0', ''),

--- a/tests/Reference/IntlTest.php
+++ b/tests/Reference/IntlTest.php
@@ -51,13 +51,6 @@ class PHP_CompatInfo_Reference_IntlTest
         if (PATH_SEPARATOR == ';') {
             // Win*
             $this->optionalclasses  = array('IntlException');
-            $this->ignoredfunctions = array(
-                'intltz_get_unknown',
-                'intlcal_get_repeated_wall_time_option',
-                'intlcal_get_skipped_wall_time_option',
-                'intlcal_set_repeated_wall_time_option',
-                'intlcal_set_skipped_wall_time_option',
-            );
         }
 
         if (version_compare(INTL_ICU_VERSION, '3.8.0', 'lt')) {
@@ -66,6 +59,30 @@ class PHP_CompatInfo_Reference_IntlTest
                 $this->optionalconstants,
                 array(
                     'U_IDNA_DOMAIN_NAME_TOO_LONG_ERROR',
+                )
+            );
+        }
+
+        if (version_compare(INTL_ICU_VERSION, '4.8', 'lt')) {
+            // requires libicu >= 4.8
+            $this->optionalfunctions = array_merge(
+                $this->optionalfunctions,
+                array(
+                    'intltz_create_time_zone_id_enumeration',
+                    'intltz_get_region',
+                )
+            );
+        }
+        if (version_compare(INTL_ICU_VERSION, '49', 'lt')) {
+            // requires libicu >= 49 (version scheme change 4.9 become 49)
+            $this->optionalfunctions = array_merge(
+                $this->optionalfunctions,
+                array(
+                    'intltz_get_unknown',
+                    'intlcal_get_repeated_wall_time_option',
+                    'intlcal_get_skipped_wall_time_option',
+                    'intlcal_set_repeated_wall_time_option',
+                    'intlcal_set_skipped_wall_time_option',
                 )
             );
         }


### PR DESCRIPTION
This new functions doesn't need to be ignored on Windows as also present under linux, but instead are optionnal for old libicu version.
