### PR TITLE
Fix notice: check if array key exists before the value gets returned in PHP/CompatInfo/Filter.php

### DIFF
--- a/PHP/CompatInfo/Filter.php
+++ b/PHP/CompatInfo/Filter.php
@@ -66,7 +66,8 @@ abstract class PHP_CompatInfo_Filter
             foreach ($items as $name => $values) {
                 if (isset($values['versions'])) {
                     $compare = $extension
-                        ? $values['versions'][2] : $values['versions'][0];
+                        ? (isset($values['versions'][2]) ? $values['versions'][2] : $values['versions'][0])
+                        : $values['versions'][0];
                 } else {
                     $compare = $extension ? $values[2] : $values[0];
                 }


### PR DESCRIPTION
This patch fixes a notice, when running `phpcompatinfo -vv print -R --reference ALL --report function --filter-version 5.2.6 ./Zend/` against Zend Framewoek 1.12.3

```
Undefined index: 2 in PHP/CompatInfo/Filter.php on line 69
```
