### PR TITLE
fixes #116 - removes empty email address from composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -43,7 +43,6 @@
         },
         {
             "name": "Remi Collet",
-            "email": "",
             "homepage": "https://github.com/remicollet",
             "role": "Contributor"
         }


### PR DESCRIPTION
It is not allowed to have an empty email address in a composer.json file.
