### PR TITLE
fixes wrong requirement of PATHINFO_FILENAME

### DIFF
--- a/src/Bartlett/CompatInfo/Reference/Extension/StandardExtension.php
+++ b/src/Bartlett/CompatInfo/Reference/Extension/StandardExtension.php
@@ -1264,6 +1264,23 @@ class StandardExtension extends AbstractReference
         return $release;
     }
 
+    protected function getR50200rc1()
+    {
+        $release = new \stdClass;
+        $release->info = array(
+            'ext.min' => '5.2.0RC1',
+            'ext.max' => '',
+            'state'   => 'beta',
+            'date'    => '2006-07-24',
+            'php.min' => '5.2.0RC1',
+            'php.max' => '',
+        );
+        $release->constants = array(
+            'PATHINFO_FILENAME'             => null,
+        );
+        return $release;
+    }
+
     protected function getR50200()
     {
         $release = new \stdClass;
@@ -1279,9 +1296,6 @@ class StandardExtension extends AbstractReference
             'array_fill_keys'               => null,
             'error_get_last'                => null,
             'memory_get_peak_usage'         => null,
-        );
-        $release->constants = array(
-            'PATHINFO_FILENAME'             => null,
         );
         return $release;
     }


### PR DESCRIPTION
The constant `PATHINFO_FILENAME` was introduced with PHP 5.2.0, not with 4.0.0, see [the manual](http://php.net/manual/en/function.pathinfo.php#refsect1-function.pathinfo-changelog) and also http://3v4l.org/doI6L.
