### PR TITLE
allow to set compatinfo.sqlite path using BARTLETT_COMPATINFO_DB

### DIFF
--- a/src/Bartlett/CompatInfo/Environment.php
+++ b/src/Bartlett/CompatInfo/Environment.php
@@ -22,6 +22,10 @@ class Environment
      */
     public static function initRefDb()
     {
+        if ($database = getenv('BARTLETT_COMPATINFO_DB')) {
+            return new \PDO('sqlite:' . $database);
+        }
+
         $database = 'compatinfo.sqlite';
         $tempDir  = sys_get_temp_dir() . '/bartlett';
 


### PR DESCRIPTION
This will also allow to avoid the copy (required in .phar).

Notice: for downstream, having "data" file outside the "Bartlett" directory seems bad, and having it in the include path even worst.

I plan to set, in the launcher,:

       BARTLETT_COMPATINFO_DB=/usr/share/php-bartlett-PHP-CompatInfo/compatinfo.sqlite