### PR TITLE
fic stomp reference

### DIFF
--- a/data/references/Stomp1.methods.json
+++ b/data/references/Stomp1.methods.json
@@ -8,5 +8,15 @@
         "ext_max": "",
         "php_min": "5.2.2",
         "php_max": ""
+    },
+    {
+        "ext_name_fk": 79,
+        "class_name": "Stomp",
+        "name": "nack",
+        "static": false,
+        "ext_min": "1.0.6",
+        "ext_max": "",
+        "php_min": "5.2.2",
+        "php_max": ""
     }
 ]


### PR DESCRIPTION
Stomp::nack method introduced in 1.0.6 with stomp_nack function