### PR TITLE
fix "php -l" reported warning in src (7.4)

### DIFF
--- a/src/Bartlett/CompatInfo/Sniffs/PHP/DocStringSyntaxSniff.php
+++ b/src/Bartlett/CompatInfo/Sniffs/PHP/DocStringSyntaxSniff.php
@@ -100,7 +100,7 @@ class DocStringSyntaxSniff extends SniffAbstract
     {
         $i = $node->getAttribute('startTokenPos');
         return (strpos($this->tokens[$i][1], "<<<") === 0
-            && $this->tokens[$i][1]{3} !== "'"
+            && $this->tokens[$i][1][3] !== "'"
         );
     }
 


### PR DESCRIPTION
```
$ find src -name \*.php -exec php74 -l {} \;
...
PHP Deprecated:  Array and string offset access syntax with curly braces is deprecated in src/Bartlett/CompatInfo/Sniffs/PHP/DocStringSyntaxSniff.php on line 103
...
```