### PR TITLE
fix named parameters confusion with PHP 8

### DIFF
--- a/src/Bartlett/CompatInfo/Console/CommandFactory.php
+++ b/src/Bartlett/CompatInfo/Console/CommandFactory.php
@@ -318,7 +318,7 @@ class CommandFactory
             try {
                 $response = call_user_func_array(
                     array($api, $methodName),
-                    $args
+                    array_values($args)
                 );
             } catch (\Exception $e) {
                 $response = $e;
@@ -363,8 +363,9 @@ class CommandFactory
                 return;
             }
 
-            if (!method_exists($outputFormatter, $methodName)
-                || !is_callable(array($outputFormatter, $methodName))
+            $result = new $outputFormatter();
+            if (!method_exists($result, $methodName)
+                || !is_callable(array($result, $methodName))
                 || $output->isDebug()
             ) {
                 $style = 'debug';
@@ -375,7 +376,6 @@ class CommandFactory
                 return;
             }
 
-            $result = new $outputFormatter();
 
             if ($response instanceof Profile) {
                 $data = $response->getData();


### PR DESCRIPTION
Without this fix:

```
PHP Fatal error:  Uncaught Error: Unknown named parameter $stop-on-failure in /work/GIT/php-compat-info/src/Bartlett/CompatInfo/Console/CommandFactory.php:320
Stack trace:
#0 /work/GIT/php-compat-info/src/Bartlett/CompatInfo/Console/CommandFactory.php(320): call_user_func_array()
#1 /work/GIT/php-compat-info/vendor/symfony/console/Command/Command.php(256): Bartlett\CompatInfo\Console\CommandFactory->Bartlett\CompatInfo\Console\{closure}()
#2 /work/GIT/php-compat-info/vendor/symfony/console/Application.php(938): Symfony\Component\Console\Command\Command->run()
#3 /work/GIT/php-compat-info/vendor/symfony/console/Application.php(266): Symfony\Component\Console\Application->doRunCommand()
#4 /work/GIT/php-compat-info/src/Bartlett/CompatInfo/Console/Application.php(217): Symfony\Component\Console\Application->doRun()
#5 /work/GIT/php-compat-info/vendor/symfony/console/Application.php(142): Bartlett\CompatInfo\Console\Application->doRun()
#6 /work/GIT/php-compat-info/src/Bartlett/CompatInfo/Console/Application.php(192): Symfony\Component\Console\Application->run()
#7 /work/GIT/php-compat-info/bin/phpcompatinfo(27): Bartlett\CompatInfo\Console\Application->run()
#8 {main}
  thrown in /work/GIT/php-compat-info/src/Bartlett/CompatInfo/Console/CommandFactory.php on line 320
```

Fo the is_callable call, need to understand why syntax_only is now required