### PR TITLE
fix: guard against missing $data[$type] key in VersionDataCollector

### DIFF
--- a/src/Application/DataCollector/VersionDataCollector.php
+++ b/src/Application/DataCollector/VersionDataCollector.php
@@ -124,7 +124,7 @@ final class VersionDataCollector extends DataCollector
                 foreach ($versions['parents'] ?? [] as $parent) {
                     $type = key($parent);
                     $id = reset($parent);
-                    if (isset($data[$type][$id]) || array_key_exists($id, $data[$type])) {
+                    if (isset($data[$type]) && (isset($data[$type][$id]) || array_key_exists($id, $data[$type]))) {
                         $this->updateElementVersion($data[$type][$id], $versions);
                     }
                 }


### PR DESCRIPTION
## Problem

`VersionDataCollector::getData()` iterates over each element's `parents` array to propagate
version constraints up the AST hierarchy. The condition used to check whether a parent exists
before updating it was:

```php
if (isset($data[$type][$id]) || array_key_exists($id, $data[$type]))
```

In PHP 8, `array_key_exists()` requires its second argument to be an array. When `$data[$type]`
does not exist, `isset($data[$type][$id])` safely returns `false`, but the `||` then forces
evaluation of `array_key_exists($id, $data[$type])`, passing `null` as the second argument —
throwing a `TypeError`.

This occurs when a parent element references a transient node type introduced by sniffs during
analysis that was not part of the original `$dataKeysAllowed` set.

## Fix

Added `isset($data[$type]) &&` as a short-circuit guard so that `array_key_exists` is never
reached when `$data[$type]` is absent:

```php
if (isset($data[$type]) && (isset($data[$type][$id]) || array_key_exists($id, $data[$type])))
```